### PR TITLE
Change endpoint to create PURL to /a/domains/{domain}/purls/{name}

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -34,7 +34,7 @@ paths:
         410:
           description: PURL not resolved as it is not available anymore.
 
-  /a/{domain}/{name}:
+  /a/domains/{domain}/purls/{name}:
     put:
       operationId: savePURL
       summary: Create or update a PURL

--- a/api/server_routes.go
+++ b/api/server_routes.go
@@ -4,5 +4,6 @@ import "github.com/gin-gonic/gin"
 
 func SetupRouting(r gin.IRouter, s *Server) {
 	r.GET("/r/:domain/:name", s.Resolve)
-	r.PUT("/a/:domain/:name", s.Save)
+
+	r.PUT("/a/domains/:domain/purls/:name", s.Save)
 }

--- a/api/server_routes.go
+++ b/api/server_routes.go
@@ -3,7 +3,9 @@ package api
 import "github.com/gin-gonic/gin"
 
 func SetupRouting(r gin.IRouter, s *Server) {
+	// Resolve endpoints
 	r.GET("/r/:domain/:name", s.Resolve)
 
+	// Admin endpoints
 	r.PUT("/a/domains/:domain/purls/:name", s.Save)
 }

--- a/tests/driver/http.go
+++ b/tests/driver/http.go
@@ -55,7 +55,7 @@ func (driver *HTTPDriver) purlPath(domain string, name string) string {
 }
 
 func (driver *HTTPDriver) adminPath(domain string, name string) string {
-	return fmt.Sprintf("%s/a/%s/%s", driver.BasePath, domain, name)
+	return fmt.Sprintf("%s/a/domains/%s/purls/%s", driver.BasePath, domain, name)
 }
 
 func (driver *HTTPDriver) CreatePurl(purl *dsl.PURL) error {

--- a/tests/dsl/given.go
+++ b/tests/dsl/given.go
@@ -1,18 +1,19 @@
 package dsl
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-// Service defines admin features of the application.
-type Service interface {
+// AdminAPI defines admin features of the application.
+type AdminAPI interface {
 	CreatePurl(purl *PURL) error
 }
 
 // GivenExistingPURL ensures that a PURL is known to the application.
 // This is done by simply creating it.
-func GivenExistingPURL(t *testing.T, service Service, purl *PURL) {
+func GivenExistingPURL(t *testing.T, service AdminAPI, purl *PURL) {
 	err := service.CreatePurl(purl)
 	require.NoError(t, err, "creating purl failed")
 }

--- a/tests/specs/resolve.go
+++ b/tests/specs/resolve.go
@@ -1,21 +1,22 @@
 package specs
 
 import (
-	"github.com/fabiante/persurl/tests/dsl"
-	"github.com/stretchr/testify/require"
 	"net/url"
 	"testing"
+
+	"github.com/fabiante/persurl/tests/dsl"
+	"github.com/stretchr/testify/require"
 )
 
-type Resolver interface {
-	dsl.Service
+type ResolveAPI interface {
+	dsl.AdminAPI
 
 	// ResolvePURL resolves the PURL identified by domain and name, returning
 	// the target of the resolved PURL.
 	ResolvePURL(domain string, name string) (*url.URL, error)
 }
 
-func TestResolver(t *testing.T, resolver Resolver) {
+func TestResolver(t *testing.T, resolver ResolveAPI) {
 	t.Run("does not resolve non-existant PURL", func(t *testing.T) {
 		purl, err := resolver.ResolvePURL("something-very-stupid", "should-not-exist")
 		require.Error(t, err)


### PR DESCRIPTION
This is more explicit for integrators.

The resolve endpoint remains as-is because shorter URLs are
preferred for resolution.

Contains some refactoring.