### PR TITLE
Add GivenExistingDomain for test specs

### DIFF
--- a/tests/dsl/given.go
+++ b/tests/dsl/given.go
@@ -12,8 +12,16 @@ type AdminAPI interface {
 }
 
 // GivenExistingPURL ensures that a PURL is known to the application.
+//
 // This is done by simply creating it.
 func GivenExistingPURL(t *testing.T, service AdminAPI, purl *PURL) {
 	err := service.CreatePurl(purl)
 	require.NoError(t, err, "creating purl failed")
+}
+
+// GivenExistingDomain ensures that a Domain is known to the application.
+//
+// This currently is a no-op since domains can't explicitly be created.
+func GivenExistingDomain(t *testing.T, service AdminAPI, domain string) {
+	// no-op - Implement something here once domains can be created.
 }

--- a/tests/specs/admin.go
+++ b/tests/specs/admin.go
@@ -39,7 +39,10 @@ func TestAdministration(t *testing.T, admin dsl.AdminAPI) {
 		})
 
 		t.Run("can create valid PURL", func(t *testing.T) {
-			dsl.GivenExistingPURL(t, admin, dsl.NewPURL("my-domain", "my-name", mustParseURL("https://google.com")))
+			domain := "my-domain"
+
+			dsl.GivenExistingDomain(t, admin, domain)
+			dsl.GivenExistingPURL(t, admin, dsl.NewPURL(domain, "my-name", mustParseURL("https://google.com")))
 		})
 	})
 }

--- a/tests/specs/admin.go
+++ b/tests/specs/admin.go
@@ -37,5 +37,9 @@ func TestAdministration(t *testing.T, admin dsl.AdminAPI) {
 				})
 			}
 		})
+
+		t.Run("can create valid PURL", func(t *testing.T) {
+			dsl.GivenExistingPURL(t, admin, dsl.NewPURL("my-domain", "my-name", mustParseURL("https://google.com")))
+		})
 	})
 }

--- a/tests/specs/resolve.go
+++ b/tests/specs/resolve.go
@@ -29,6 +29,7 @@ func TestResolver(t *testing.T, resolver ResolveAPI) {
 			domain := "my-domain"
 			name := "my-name"
 
+			dsl.GivenExistingDomain(t, resolver, domain)
 			dsl.GivenExistingPURL(t, resolver, dsl.NewPURL(domain, name, mustParseURL("https://google.com")))
 
 			purl, err := resolver.ResolvePURL(domain, name)


### PR DESCRIPTION
This prepares tests for future changes, which may add an API to
explicitly create a domain (see #10)