### PR TITLE
Fix PURL creation without existing domain

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -44,9 +44,17 @@ func (s *Server) SavePURL(ctx *gin.Context) {
 		return
 	}
 
-	s.service.SavePURL(domain, name, req.Target)
-
-	ctx.Status(http.StatusNoContent)
+	err := s.service.SavePURL(domain, name, req.Target)
+	switch true {
+	case err == nil:
+		ctx.Status(http.StatusNoContent)
+		return
+	case errors.Is(err, app.ErrBadRequest):
+		ctx.Status(http.StatusBadRequest)
+		return
+	default:
+		_ = ctx.AbortWithError(http.StatusInternalServerError, err)
+	}
 }
 
 func (s *Server) CreateDomain(ctx *gin.Context) {

--- a/api/server.go
+++ b/api/server.go
@@ -40,7 +40,8 @@ func (s *Server) SavePURL(ctx *gin.Context) {
 
 	var req res.SavePURL
 	if err := ctx.BindJSON(&req); err != nil {
-		panic(err)
+		ctx.Abort()
+		return
 	}
 
 	s.service.SavePURL(domain, name, req.Target)

--- a/app/service.go
+++ b/app/service.go
@@ -4,35 +4,43 @@ import (
 	"fmt"
 )
 
-type serviceMap = map[string]string
-
 // Service is an in-memory implementation of this application's
 // features.
 //
 // It meant as short-term type used until an actual persistence layer is required.
 type Service struct {
-	data serviceMap
+	data DomainMap
 }
 
 func NewService() *Service {
 	return &Service{
-		data: make(serviceMap),
+		data: make(DomainMap),
 	}
 }
 
 func (s *Service) Resolve(domain, name string) (string, error) {
-	target := s.data[fmt.Sprintf("%s/%s", domain, name)]
-	if target != "" {
-		return target, nil
+	purls, found := s.data[domain]
+	if !found {
+		return "", ErrNotFound
 	}
-	return "", ErrNotFound
+	return purls.ResolvePURL(name)
 }
 
-func (s *Service) SavePURL(domain, name string, target string) {
-	s.data[fmt.Sprintf("%s/%s", domain, name)] = target
+func (s *Service) SavePURL(domain, name, target string) error {
+	purls, found := s.data[domain]
+	if !found {
+		return fmt.Errorf("%w: domain does not exist", ErrBadRequest)
+	}
+
+	purls.CreatePurl(name, target)
+	return nil
 }
 
 func (s *Service) CreateDomain(domain string) error {
-	// currently a no-op
+	if _, found := s.data[domain]; found {
+		return fmt.Errorf("%w: domain already exists", ErrBadRequest)
+	}
+
+	s.data[domain] = make(PurlMap)
 	return nil
 }

--- a/app/service_maps.go
+++ b/app/service_maps.go
@@ -1,0 +1,25 @@
+package app
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/fabiante/persurl/tests/dsl"
+)
+
+type DomainMap map[string]PurlMap
+
+type PurlMap map[string]*dsl.PURL
+
+func (m PurlMap) CreatePurl(purl *dsl.PURL) error {
+	m[purl.Name] = purl
+	return nil
+}
+
+func (m PurlMap) ResolvePURL(name string) (*url.URL, error) {
+	if purl, purlExists := m[name]; purlExists {
+		return purl.Target, nil
+	}
+
+	return nil, fmt.Errorf("%w: purl does not exist", ErrNotFound)
+}

--- a/app/service_maps.go
+++ b/app/service_maps.go
@@ -8,9 +8,8 @@ type DomainMap map[string]PurlMap
 
 type PurlMap map[string]string
 
-func (m PurlMap) CreatePurl(name string, target string) error {
+func (m PurlMap) CreatePurl(name string, target string) {
 	m[name] = target
-	return nil
 }
 
 func (m PurlMap) ResolvePURL(name string) (string, error) {

--- a/app/service_maps.go
+++ b/app/service_maps.go
@@ -2,24 +2,21 @@ package app
 
 import (
 	"fmt"
-	"net/url"
-
-	"github.com/fabiante/persurl/tests/dsl"
 )
 
 type DomainMap map[string]PurlMap
 
-type PurlMap map[string]*dsl.PURL
+type PurlMap map[string]string
 
-func (m PurlMap) CreatePurl(purl *dsl.PURL) error {
-	m[purl.Name] = purl
+func (m PurlMap) CreatePurl(name string, target string) error {
+	m[name] = target
 	return nil
 }
 
-func (m PurlMap) ResolvePURL(name string) (*url.URL, error) {
+func (m PurlMap) ResolvePURL(name string) (string, error) {
 	if purl, purlExists := m[name]; purlExists {
-		return purl.Target, nil
+		return purl, nil
 	}
 
-	return nil, fmt.Errorf("%w: purl does not exist", ErrNotFound)
+	return "", fmt.Errorf("%w: purl does not exist", ErrNotFound)
 }

--- a/tests/specs/admin.go
+++ b/tests/specs/admin.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/fabiante/persurl/app"
 	"github.com/fabiante/persurl/tests/dsl"
 	"github.com/stretchr/testify/require"
 )
@@ -41,6 +42,14 @@ func testPurlAdmin(t *testing.T, admin dsl.AdminAPI) {
 				//require.ErrorIs(t, err, app.ErrBadRequest) // TODO: Some tests cause a 404 with the http driver.
 			})
 		}
+	})
+
+	t.Run("can't create PURL on non-existent domain", func(t *testing.T) {
+		domain := "this-domain-does-not-exist-it-should-not"
+		purl := dsl.NewPURL(domain, "my-name3456334654645663456", mustParseURL("https://google.com"))
+
+		err := admin.SavePURL(purl)
+		require.ErrorIs(t, err, app.ErrBadRequest)
 	})
 
 	t.Run("can create new PURL", func(t *testing.T) {

--- a/tests/specs/admin.go
+++ b/tests/specs/admin.go
@@ -58,7 +58,7 @@ func testPurlAdmin(t *testing.T, admin dsl.AdminAPI) {
 
 		dsl.GivenExistingDomain(t, admin, domain)
 		// TODO: Assert non-existence of purl to be created
-		dsl.GivenExistingPURL(t, admin, purl)
+		require.NoError(t, admin.SavePURL(purl), "creating purl failed")
 	})
 
 	t.Run("can update existing purl", func(t *testing.T) {


### PR DESCRIPTION
This generally fixes the implementation of #15 which did not properly test how domain existence relates to the administration of purls.