### PR TITLE
Fix imports of goqu sqlite3 driver packages

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/doug-martin/goqu/v9"
+	_ "github.com/doug-martin/goqu/v9/dialect/sqlite3"
 	"github.com/fabiante/persurl/api"
 	"github.com/fabiante/persurl/db"
 	"github.com/gin-gonic/gin"

--- a/db/database.go
+++ b/db/database.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	"github.com/doug-martin/goqu/v9"
-	_ "github.com/doug-martin/goqu/v9/dialect/sqlite3"
 	"github.com/doug-martin/goqu/v9/exec"
 	"github.com/fabiante/persurl/app"
 	"modernc.org/sqlite"

--- a/tests/http_test.go
+++ b/tests/http_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/doug-martin/goqu/v9"
+	_ "github.com/doug-martin/goqu/v9/dialect/sqlite3"
 	"github.com/fabiante/persurl/api"
 	"github.com/fabiante/persurl/db"
 	"github.com/fabiante/persurl/tests/driver"


### PR DESCRIPTION
These packages should be imported in the "main" entrypoints of the application / tests.