### PR TITLE
Add support for periods in domain and purl names

### DIFF
--- a/api/validate.go
+++ b/api/validate.go
@@ -13,7 +13,7 @@ var regexNamed *regexp.Regexp
 func init() {
 	// regexNamed is used to validate everything that has a name. See OpenAPI
 	// for more information.
-	regexNamed = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+	regexNamed = regexp.MustCompile(`^[a-zA-Z0-9\\._-]+$`)
 }
 
 // validPathVar is a middleware that validates a path variable against a

--- a/tests/specs/admin.go
+++ b/tests/specs/admin.go
@@ -99,8 +99,17 @@ func testDomainAdmin(t *testing.T, admin dsl.AdminAPI) {
 	})
 
 	t.Run("can create valid domain", func(t *testing.T) {
-		err := admin.CreateDomain("awesome-domain-unique-name-123")
-		require.NoError(t, err)
+		valid := []string{
+			"awesome-domain-unique-name-123",
+			"awesome.com",
+		}
+
+		for i, v := range valid {
+			t.Run(fmt.Sprintf("valid[%d]", i), func(*testing.T) {
+				err := admin.CreateDomain(v)
+				require.NoError(t, err)
+			})
+		}
 	})
 
 	t.Run("can't create duplicate domain", func(t *testing.T) {

--- a/tests/specs/admin.go
+++ b/tests/specs/admin.go
@@ -54,11 +54,19 @@ func testPurlAdmin(t *testing.T, admin dsl.AdminAPI) {
 
 	t.Run("can create new PURL", func(t *testing.T) {
 		domain := "my-domain-123456"
-		purl := dsl.NewPURL(domain, "my-name3456345663456", mustParseURL("https://google.com"))
-
 		dsl.GivenExistingDomain(t, admin, domain)
-		// TODO: Assert non-existence of purl to be created
-		require.NoError(t, admin.SavePURL(purl), "creating purl failed")
+
+		validPurls := []*dsl.PURL{
+			dsl.NewPURL(domain, "my-name3456345663456", mustParseURL("https://google.com")),
+			dsl.NewPURL(domain, "my-purl.com", mustParseURL("https://google.com")),
+		}
+
+		for i, purl := range validPurls {
+			t.Run(fmt.Sprintf("valid[%d]", i), func(t *testing.T) {
+				// TODO: Assert non-existence of purl to be created
+				require.NoError(t, admin.SavePURL(purl), "creating purl failed")
+			})
+		}
 	})
 
 	t.Run("can update existing purl", func(t *testing.T) {


### PR DESCRIPTION
This closes #21 

This allows users to create domains like `example.com` and purls like `my-resource.custom.local`