### PR TITLE
Change purl save endpoint to respond with purl's path

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -67,8 +67,16 @@ paths:
               required:
                 - target
       responses:
-        204:
+        200:
           description: PURL created or updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  path:
+                    type: string
+                    example: /r/your-domain/your-purl
         400:
           $ref: "#/components/responses/BadRequest"
 

--- a/api/res/admin.go
+++ b/api/res/admin.go
@@ -3,3 +3,13 @@ package res
 type SavePURL struct {
 	Target string `json:"target"`
 }
+
+type SavePURLResponse struct {
+	Path string `json:"path"`
+}
+
+func NewSavePURLResponse(path string) *SavePURLResponse {
+	return &SavePURLResponse{
+		Path: path,
+	}
+}

--- a/api/server.go
+++ b/api/server.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/fabiante/persurl/api/res"
@@ -47,12 +48,14 @@ func (s *Server) SavePURL(ctx *gin.Context) {
 	err := s.service.SavePURL(domain, name, req.Target)
 	switch true {
 	case err == nil:
-		ctx.Status(http.StatusNoContent)
+		break
 	case errors.Is(err, app.ErrBadRequest):
 		respondWithError(ctx, http.StatusBadRequest, err)
 	default:
 		respondWithError(ctx, http.StatusInternalServerError, err)
 	}
+
+	ctx.JSON(http.StatusOK, res.NewSavePURLResponse(fmt.Sprintf("/r/%s/%s", domain, name)))
 }
 
 func (s *Server) CreateDomain(ctx *gin.Context) {

--- a/tests/driver/http.go
+++ b/tests/driver/http.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/fabiante/persurl/api/res"
 	"github.com/fabiante/persurl/app"
 	"github.com/fabiante/persurl/tests/dsl"
 )
@@ -51,32 +52,39 @@ func (driver *HTTPDriver) ResolvePURL(domain string, name string) (*url.URL, err
 	return loc, nil
 }
 
-func (driver *HTTPDriver) SavePURL(purl *dsl.PURL) error {
+func (driver *HTTPDriver) SavePURL(purl *dsl.PURL) (string, error) {
 	body := bytes.NewBuffer([]byte{})
 	err := json.NewEncoder(body).Encode(map[string]string{
 		"target": purl.Target.String(),
 	})
 	if err != nil {
-		return err
+		return "", err
 	}
 	req, err := http.NewRequest(http.MethodPut, fmt.Sprintf("%s/a/domains/%s/purls/%s", driver.BasePath, purl.Domain, purl.Name), body)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	res, err := driver.Client.Do(req)
+	response, err := driver.Client.Do(req)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	switch res.StatusCode {
-	case http.StatusNoContent:
-		return nil
+	switch response.StatusCode {
+	case http.StatusOK:
+		break
 	case http.StatusBadRequest:
-		return fmt.Errorf("%w: status %d returned", app.ErrBadRequest, res.StatusCode)
+		return "", fmt.Errorf("%w: status %d returned", app.ErrBadRequest, response.StatusCode)
 	default:
-		return fmt.Errorf("unexpected status code: %d", res.StatusCode)
+		return "", fmt.Errorf("unexpected status code: %d", response.StatusCode)
 	}
+
+	var r res.SavePURLResponse
+	if err := json.NewDecoder(response.Body).Decode(&r); err != nil {
+		return "", fmt.Errorf("decoding response body failed: %w", err)
+	}
+
+	return r.Path, nil
 }
 
 func (driver *HTTPDriver) CreateDomain(name string) error {

--- a/tests/driver/http.go
+++ b/tests/driver/http.go
@@ -29,21 +29,21 @@ func NewHTTPDriver(basePath string, transport http.RoundTripper) *HTTPDriver {
 }
 
 func (driver *HTTPDriver) ResolvePURL(domain string, name string) (*url.URL, error) {
-	res, err := driver.Client.Get(fmt.Sprintf("%s/r/%s/%s", driver.BasePath, domain, name))
+	response, err := driver.Client.Get(fmt.Sprintf("%s/r/%s/%s", driver.BasePath, domain, name))
 	if err != nil {
 		return nil, err
 	}
 
-	switch res.StatusCode {
+	switch response.StatusCode {
 	case http.StatusFound:
 		break
 	case http.StatusNotFound:
-		return nil, fmt.Errorf("%w: status %d returned", app.ErrNotFound, res.StatusCode)
+		return nil, fmt.Errorf("%w: status %d returned", app.ErrNotFound, response.StatusCode)
 	default:
-		return nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
+		return nil, fmt.Errorf("unexpected status code: %d", response.StatusCode)
 	}
 
-	loc, err := res.Location()
+	loc, err := response.Location()
 	if err != nil {
 		return nil, fmt.Errorf("invalid location: %s", err)
 	}
@@ -85,17 +85,17 @@ func (driver *HTTPDriver) CreateDomain(name string) error {
 		return err
 	}
 
-	res, err := driver.Client.Do(req)
+	response, err := driver.Client.Do(req)
 	if err != nil {
 		return err
 	}
 
-	switch res.StatusCode {
+	switch response.StatusCode {
 	case http.StatusNoContent:
 		return nil
 	case http.StatusBadRequest:
-		return fmt.Errorf("%w: status %d returned", app.ErrBadRequest, res.StatusCode)
+		return fmt.Errorf("%w: status %d returned", app.ErrBadRequest, response.StatusCode)
 	default:
-		return fmt.Errorf("unexpected status code: %d", res.StatusCode)
+		return fmt.Errorf("unexpected status code: %d", response.StatusCode)
 	}
 }

--- a/tests/dsl/apis.go
+++ b/tests/dsl/apis.go
@@ -7,7 +7,9 @@ type AdminAPI interface {
 	CreateDomain(name string) error
 
 	// SavePURL creates a new or updates an existing purl.
-	SavePURL(purl *PURL) error
+	//
+	// If no error occurred the returned string is the path (without host) of the created PURL.
+	SavePURL(purl *PURL) (string, error)
 }
 
 // ResolveAPI defines features for PURL resolution.

--- a/tests/dsl/given.go
+++ b/tests/dsl/given.go
@@ -10,8 +10,9 @@ import (
 //
 // This is done by simply creating it.
 func GivenExistingPURL(t *testing.T, service AdminAPI, purl *PURL) {
-	err := service.SavePURL(purl)
+	path, err := service.SavePURL(purl)
 	require.NoError(t, err, "saving purl failed")
+	require.NotEmpty(t, path)
 }
 
 // GivenExistingDomain ensures that a Domain is known to the application.

--- a/tests/load/agent_create.go
+++ b/tests/load/agent_create.go
@@ -45,8 +45,9 @@ func (a *CreateAgent) Run(t *testing.T, done <-chan struct{}, wg *sync.WaitGroup
 	for {
 		name := fmt.Sprintf("purl-%d", i)
 
-		err := a.API.SavePURL(dsl.NewPURL(a.Domain, name, target))
+		path, err := a.API.SavePURL(dsl.NewPURL(a.Domain, name, target))
 		require.NoError(t, err)
+		require.NotEmpty(t, path)
 
 		i += 1
 		select {

--- a/tests/specs/admin.go
+++ b/tests/specs/admin.go
@@ -37,7 +37,7 @@ func testPurlAdmin(t *testing.T, admin dsl.AdminAPI) {
 
 		for i, purl := range invalid {
 			t.Run(fmt.Sprintf("invalid[%d]", i), func(t *testing.T) {
-				err := admin.SavePURL(purl)
+				_, err := admin.SavePURL(purl)
 				require.Error(t, err)
 				//require.ErrorIs(t, err, app.ErrBadRequest) // TODO: Some tests cause a 404 with the http driver.
 			})
@@ -48,7 +48,7 @@ func testPurlAdmin(t *testing.T, admin dsl.AdminAPI) {
 		domain := "this-domain-does-not-exist-it-should-not"
 		purl := dsl.NewPURL(domain, "my-name3456334654645663456", mustParseURL("https://google.com"))
 
-		err := admin.SavePURL(purl)
+		_, err := admin.SavePURL(purl)
 		require.ErrorIs(t, err, app.ErrBadRequest)
 	})
 
@@ -64,7 +64,9 @@ func testPurlAdmin(t *testing.T, admin dsl.AdminAPI) {
 		for i, purl := range validPurls {
 			t.Run(fmt.Sprintf("valid[%d]", i), func(t *testing.T) {
 				// TODO: Assert non-existence of purl to be created
-				require.NoError(t, admin.SavePURL(purl), "creating purl failed")
+				path, err := admin.SavePURL(purl)
+				require.NoError(t, err, "creating purl failed")
+				require.NotEmpty(t, path)
 			})
 		}
 	})
@@ -76,7 +78,9 @@ func testPurlAdmin(t *testing.T, admin dsl.AdminAPI) {
 		dsl.GivenExistingDomain(t, admin, domain)
 		dsl.GivenExistingPURL(t, admin, purl)
 
-		require.NoError(t, admin.SavePURL(purl), "updating existing purl failed")
+		path, err := admin.SavePURL(purl)
+		require.NoError(t, err, "updating existing purl failed")
+		require.NotEmpty(t, path)
 	})
 }
 


### PR DESCRIPTION
This closes #23 

This is a smaller implementation which reponds with the path but not the host / domain of the purl. Clients still have to combine host + path if they want to use a PURL but at least they now simply have to save the path instead of the domain + name combination.