### PR TITLE
Fix admin test 'can update existing purl'

### DIFF
--- a/tests/specs/admin.go
+++ b/tests/specs/admin.go
@@ -78,9 +78,13 @@ func testPurlAdmin(t *testing.T, admin dsl.AdminAPI) {
 		dsl.GivenExistingDomain(t, admin, domain)
 		dsl.GivenExistingPURL(t, admin, purl)
 
+		// modify purl's name - updating the target would be the usual case but that is harder to assert.
+		purl.Name = "my-new-name-updated"
+
 		path, err := admin.SavePURL(purl)
 		require.NoError(t, err, "updating existing purl failed")
 		require.NotEmpty(t, path)
+		require.Contains(t, path, "my-new-name-updated")
 	})
 }
 


### PR DESCRIPTION
This did not assert that the update of a purl actually happened.

The added assertion + target change ensures that the seconds SavePURL call actually does something.