### PR TITLE
Add users table

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -11,10 +11,11 @@ import (
 type Server struct {
 	resolver app.ResolveServiceInterface
 	admin    app.AdminServiceInterface
+	user     app.UserServiceInterface
 }
 
-func NewServer(resolver app.ResolveServiceInterface, admin app.AdminServiceInterface) *Server {
-	return &Server{resolver: resolver, admin: admin}
+func NewServer(resolver app.ResolveServiceInterface, admin app.AdminServiceInterface, user app.UserServiceInterface) *Server {
+	return &Server{resolver: resolver, admin: admin, user: user}
 }
 
 func (s *Server) Resolve(ctx *gin.Context) {

--- a/api/server_admin.go
+++ b/api/server_admin.go
@@ -48,7 +48,7 @@ func (s *Server) SavePURL(ctx *gin.Context) {
 func (s *Server) CreateDomain(ctx *gin.Context) {
 	domain := ctx.Param("domain")
 
-	err := s.admin.CreateDomain(domain)
+	_, err := s.admin.CreateDomain(domain)
 	switch true {
 	case err == nil:
 		ctx.Status(http.StatusNoContent)

--- a/app/models/user.go
+++ b/app/models/user.go
@@ -1,0 +1,9 @@
+package models
+
+import "gorm.io/gorm"
+
+type User struct {
+	gorm.Model
+
+	Email string
+}

--- a/app/service.go
+++ b/app/service.go
@@ -34,4 +34,5 @@ type AdminServiceInterface interface {
 
 type UserServiceInterface interface {
 	CreateUser(email string) error
+	GetUser(email string) (*models.User, error)
 }

--- a/app/service.go
+++ b/app/service.go
@@ -31,3 +31,7 @@ type AdminServiceInterface interface {
 	// ErrNotFound is returned if the domain does not exist.
 	GetDomain(name string) (*models.Domain, error)
 }
+
+type UserServiceInterface interface {
+	CreateUser(email string) error
+}

--- a/app/service.go
+++ b/app/service.go
@@ -24,7 +24,7 @@ type AdminServiceInterface interface {
 	// CreateDomain creates a new domain.
 	//
 	// ErrBadRequest is returned if the domain already exists.
-	CreateDomain(domain string) error
+	CreateDomain(domain string) (*models.Domain, error)
 
 	// GetDomain returns the domain with the given name.
 	//

--- a/app/service_impl.go
+++ b/app/service_impl.go
@@ -39,18 +39,19 @@ func (s *service) Resolve(domain, name string) (string, error) {
 	}
 }
 
-func (s *service) CreateDomain(name string) error {
+func (s *service) CreateDomain(name string) (*models.Domain, error) {
 	domain := &models.Domain{
 		Name: name,
 	}
 
 	err := s.db.Create(domain).Error
 
-	if err != nil {
-		return mapDBError(err)
+	switch {
+	case err != nil:
+		return nil, mapDBError(err)
+	default:
+		return domain, nil
 	}
-
-	return nil
 }
 
 func (s *service) GetDomain(name string) (*models.Domain, error) {

--- a/app/service_user.go
+++ b/app/service_user.go
@@ -26,3 +26,15 @@ func (s *UserService) CreateUser(email string) error {
 		return nil
 	}
 }
+
+func (s *UserService) GetUser(email string) (*models.User, error) {
+	user := &models.User{}
+
+	err := s.db.Take(user, "email = ?", email).Error
+	switch {
+	case err != nil:
+		return nil, mapDBError(err)
+	default:
+		return user, nil
+	}
+}

--- a/app/service_user.go
+++ b/app/service_user.go
@@ -1,0 +1,28 @@
+package app
+
+import (
+	"github.com/fabiante/persurl/app/models"
+	"gorm.io/gorm"
+)
+
+type UserService struct {
+	db *gorm.DB
+}
+
+func NewUserService(db *gorm.DB) *UserService {
+	return &UserService{db: db}
+}
+
+func (s *UserService) CreateUser(email string) error {
+	user := &models.User{
+		Email: email,
+	}
+
+	err := s.db.Create(user).Error
+	switch {
+	case err != nil:
+		return mapDBError(err)
+	default:
+		return nil
+	}
+}

--- a/cli/cmds/run.go
+++ b/cli/cmds/run.go
@@ -25,7 +25,8 @@ func init() {
 
 		engine := gin.Default()
 		service := app.NewService(database.Gorm)
-		server := api.NewServer(service, service)
+		userService := app.NewUserService(database.Gorm)
+		server := api.NewServer(service, service, userService)
 		api.SetupRouting(engine, server)
 		if err := engine.Run(":8060"); err != nil {
 			log.Fatalf("running api failed: %s", err)

--- a/db/migrations/migrate.go
+++ b/db/migrations/migrate.go
@@ -71,4 +71,17 @@ var migrationsPostgres = []any{
         unique (domain_id, name)
 )`,
 	),
+	newMigration("2023-09-22-00000030-CreateTableUsers", `create table users
+(
+    id        serial
+        constraint user_pk
+            primary key,
+	created_at timestamp    not null,
+	updated_at timestamp,
+	deleted_at timestamp,
+    email      varchar(256)  not null,
+    constraint purls_email
+        unique (email)
+)`,
+	),
 }

--- a/tests/http_load_test.go
+++ b/tests/http_load_test.go
@@ -32,7 +32,8 @@ func TestLoadWithHTTPDriver(t *testing.T) {
 	require.NoError(t, err, "truncating tables failed")
 
 	service := app.NewService(database.Gorm)
-	server := api.NewServer(service, service)
+	userService := app.NewUserService(database.Gorm)
+	server := api.NewServer(service, service, userService)
 	api.SetupRouting(handler, server)
 
 	testServer := httptest.NewServer(handler)

--- a/tests/http_test.go
+++ b/tests/http_test.go
@@ -26,7 +26,8 @@ func TestWithHTTPDriver(t *testing.T) {
 	require.NoError(t, err, "truncating tables failed")
 
 	service := app.NewService(database.Gorm)
-	server := api.NewServer(service, service)
+	userService := app.NewUserService(database.Gorm)
+	server := api.NewServer(service, service, userService)
 	api.SetupRouting(handler, server)
 
 	testServer := httptest.NewServer(handler)


### PR DESCRIPTION
This PR introduces a yet "empty" table for maintaining users. See #2 for a discussion about the purpose of this table.

The table will be updated with more columns and relations to other tables (such as the domain table, see #81)