### PR TITLE
Refactor tests to store auth information in Context object

### DIFF
--- a/tests/http_load_test.go
+++ b/tests/http_load_test.go
@@ -39,6 +39,7 @@ func TestLoadWithHTTPDriver(t *testing.T) {
 	userService := app.NewUserService(database.Gorm)
 
 	key := dsl.GivenSomeUser(ctx, t, userService)
+	ctx = driver.CtxWithUserKey(ctx, key.Value)
 
 	server := api.NewServer(service, service, userService)
 	api.SetupRouting(handler, server)
@@ -46,7 +47,6 @@ func TestLoadWithHTTPDriver(t *testing.T) {
 	testServer := httptest.NewServer(handler)
 
 	dr := driver.NewHTTPDriver(testServer.URL, http.DefaultTransport)
-	dr.UserToken = key.Value
 
 	specs.TestLoad(t, dr)
 }

--- a/tests/http_test.go
+++ b/tests/http_test.go
@@ -32,6 +32,7 @@ func TestWithHTTPDriver(t *testing.T) {
 	userService := app.NewUserService(database.Gorm)
 
 	key := dsl.GivenSomeUser(ctx, t, userService)
+	ctx = driver.CtxWithUserKey(ctx, key.Value)
 
 	server := api.NewServer(service, service, userService)
 	api.SetupRouting(handler, server)
@@ -39,7 +40,6 @@ func TestWithHTTPDriver(t *testing.T) {
 	testServer := httptest.NewServer(handler)
 
 	dr := driver.NewHTTPDriver(testServer.URL, http.DefaultTransport)
-	dr.UserToken = key.Value
 
 	specs.TestResolver(t, dr)
 	specs.TestAdministration(t, dr)


### PR DESCRIPTION
A follow up to #91, this refactors tests to use auth information based on the given ctx value.